### PR TITLE
Making bots auto accept invites upon start of program

### DIFF
--- a/engine/bots.go
+++ b/engine/bots.go
@@ -108,7 +108,11 @@ func (b *Bot) HandleStateMemberEvent(source mautrix.EventSource, evt *event.Even
 }
 
 func (b *Bot) getInstance() MatrixClient {
-	return b.e.bots[b.ID]
+	if b.IsHydrated() {
+		return b.e.bots[b.ID]
+	}
+
+	return nil
 }
 
 func (b *Bot) JoinRoom(roomid id.RoomID) (resp *mautrix.RespJoinRoom, err error) {

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -78,7 +78,7 @@ func (b Bot) HandleStateMemberEvent(source mautrix.EventSource, evt *event.Event
 		if membership == "invite" {
 			b.log(fmt.Sprintf("Invitation for %s\n", evt.RoomID))
 
-			// ensure the invitation if for a room within our homeserver only
+			// ensure the invitation is for a room within our homeserver only
 			matrixHSHost := strings.Split(strings.Split(b.e.matrixhomeserver, "://")[1], ":")[0] // remove protocol and port info to get just the hostname
 			if strings.Split(evt.RoomID.String(), ":")[1] == matrixHSHost {
 				// join the room

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -1,7 +1,12 @@
 package engine
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/upper/db/v4"
+	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/event"
 )
 
 type Bot struct {
@@ -30,4 +35,50 @@ func getBot(dbs db.Session, identifier string) (b Bot, err error) {
 	err = res.One(&b)
 
 	return
+}
+
+func (b Bot) WakeUp(e *engine) error {
+	e.log(fmt.Sprintf("Matrix: Activating Bot: %s [%s]", b.Name, b.Identifier))
+
+	client, err := mautrix.NewClient(e.matrixhomeserver, "", "")
+	if err != nil {
+		return err
+	}
+	_, err = client.Login(&mautrix.ReqLogin{
+		Type:             "m.login.password",
+		Identifier:       mautrix.UserIdentifier{Type: mautrix.IdentifierTypeUser, User: b.Username},
+		Password:         b.Password,
+		StoreCredentials: true,
+	})
+	if err != nil {
+		return err
+	}
+	e.log(fmt.Sprintf("Matrix: Bot %s [%s] login successful", b.Name, b.Identifier))
+
+	syncer := client.Syncer.(*mautrix.DefaultSyncer)
+
+	syncer.OnEventType(event.StateMember, func(source mautrix.EventSource, evt *event.Event) {
+		if membership, ok := evt.Content.Raw["membership"]; ok {
+			if membership == "invite" {
+				e.log(fmt.Sprintf("Invitation for %s\n", evt.RoomID))
+
+				// ensure the invitation if for a room within our homeserver only
+				matrixHSHost := strings.Split(strings.Split(e.matrixhomeserver, "://")[1], ":")[0] // remove protocol and port info to get just the hostname
+				if strings.Split(evt.RoomID.String(), ":")[1] == matrixHSHost {
+					// join the room
+					_, err := client.JoinRoomByID(evt.RoomID)
+					if err != nil {
+						e.log(fmt.Sprintf("Bot couldn't join the invitation bot:%s invitation:%s", b.Name, evt.RoomID))
+					} else {
+						e.log("accepted invitation, if it wasn't accepted already")
+					}
+				} else {
+					e.log(fmt.Sprintf("whaat? %v", strings.Split(evt.RoomID.String(), ":")))
+				}
+			}
+		}
+		e.log(fmt.Sprintf("\nSource: %d\n%s  %s\n%+v\n", source, evt.Type.Type, evt.RoomID, evt.Content.Raw))
+	})
+
+	return client.Sync()
 }

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -20,6 +20,8 @@ type Bot struct {
 	CreatedBy   string `db:"created_by"`
 	Active      bool   `db:"active"`
 
+	hydrated bool
+
 	e *engine
 }
 
@@ -40,7 +42,16 @@ func getBot(dbs db.Session, identifier string) (b Bot, err error) {
 	return
 }
 
-func (b Bot) WakeUp(e *engine) (err error) {
+func (b *Bot) IsHydrated() bool {
+	return b.hydrated
+}
+
+func (b *Bot) Hydrate(e *engine) {
+	b.hydrated = true
+	b.e = e
+}
+
+func (b *Bot) WakeUp(e *engine) (err error) {
 	// save reference
 	b.e = e
 
@@ -73,7 +84,7 @@ func (b Bot) WakeUp(e *engine) (err error) {
 	return
 }
 
-func (b Bot) HandleStateMemberEvent(source mautrix.EventSource, evt *event.Event) {
+func (b *Bot) HandleStateMemberEvent(source mautrix.EventSource, evt *event.Event) {
 	if membership, ok := evt.Content.Raw["membership"]; ok {
 		if membership == "invite" {
 			b.log(fmt.Sprintf("Invitation for %s\n", evt.RoomID))
@@ -96,14 +107,14 @@ func (b Bot) HandleStateMemberEvent(source mautrix.EventSource, evt *event.Event
 	b.log(fmt.Sprintf("\nSource: %d\n%s  %s\n%+v\n", source, evt.Type.Type, evt.RoomID, evt.Content.Raw))
 }
 
-func (b Bot) getInstance() MatrixClient {
+func (b *Bot) getInstance() MatrixClient {
 	return b.e.bots[b.ID]
 }
 
-func (b Bot) JoinRoom(roomid id.RoomID) (resp *mautrix.RespJoinRoom, err error) {
+func (b *Bot) JoinRoom(roomid id.RoomID) (resp *mautrix.RespJoinRoom, err error) {
 	return b.getInstance().JoinRoomByID(roomid)
 }
 
-func (b Bot) log(m string) {
+func (b *Bot) log(m string) {
 	b.e.log(m)
 }

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -116,7 +117,11 @@ func (b *Bot) getMCInstance() MatrixClient {
 }
 
 func (b *Bot) JoinRoom(roomid id.RoomID) (resp *mautrix.RespJoinRoom, err error) {
-	return b.getMCInstance().JoinRoomByID(roomid)
+	if c := b.getMCInstance(); c != nil {
+		return c.JoinRoomByID(roomid)
+	}
+
+	return nil, errors.New("bot instance not hydrated")
 }
 
 func (b *Bot) log(m string) {

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -107,7 +107,7 @@ func (b *Bot) HandleStateMemberEvent(source mautrix.EventSource, evt *event.Even
 	b.log(fmt.Sprintf("\nSource: %d\n%s  %s\n%+v\n", source, evt.Type.Type, evt.RoomID, evt.Content.Raw))
 }
 
-func (b *Bot) getInstance() MatrixClient {
+func (b *Bot) getMCInstance() MatrixClient {
 	if b.IsHydrated() {
 		return b.e.bots[b.ID]
 	}
@@ -116,7 +116,7 @@ func (b *Bot) getInstance() MatrixClient {
 }
 
 func (b *Bot) JoinRoom(roomid id.RoomID) (resp *mautrix.RespJoinRoom, err error) {
-	return b.getInstance().JoinRoomByID(roomid)
+	return b.getMCInstance().JoinRoomByID(roomid)
 }
 
 func (b *Bot) log(m string) {

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -40,13 +40,13 @@ func getBot(dbs db.Session, identifier string) (b Bot, err error) {
 	return
 }
 
-func (b Bot) WakeUp(e *engine) (client MatrixClient, err error) {
-	e.log(fmt.Sprintf("Matrix: Activating Bot: %s [%s]", b.Name, b.Identifier))
-
+func (b Bot) WakeUp(e *engine) (err error) {
 	// save reference
 	b.e = e
 
-	client, err = mautrix.NewClient(e.matrixhomeserver, "", "")
+	b.log(fmt.Sprintf("Matrix: Activating Bot: %s [%s]", b.Name, b.Identifier))
+
+	client, err := mautrix.NewClient(e.matrixhomeserver, "", "")
 	if err != nil {
 		return
 	}
@@ -59,12 +59,15 @@ func (b Bot) WakeUp(e *engine) (client MatrixClient, err error) {
 	if err != nil {
 		return
 	}
-	e.log(fmt.Sprintf("Matrix: Bot %s [%s] login successful", b.Name, b.Identifier))
+	b.log(fmt.Sprintf("Matrix: Bot %s [%s] login successful", b.Name, b.Identifier))
 
-	syncer := client.(*mautrix.Client).Syncer.(*mautrix.DefaultSyncer)
+	syncer := client.Syncer.(*mautrix.DefaultSyncer)
 	syncer.OnEventType(event.StateMember, b.HandleStateMemberEvent)
 
 	err = client.Sync()
+
+	// save reference
+	e.bots[b.ID] = client
 
 	return
 }

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -50,6 +50,10 @@ func (b Bot) WakeUp(e *engine) (err error) {
 	if err != nil {
 		return
 	}
+
+	// save reference
+	e.bots[b.ID] = client
+
 	_, err = client.Login(&mautrix.ReqLogin{
 		Type:             "m.login.password",
 		Identifier:       mautrix.UserIdentifier{Type: mautrix.IdentifierTypeUser, User: b.Username},
@@ -65,9 +69,6 @@ func (b Bot) WakeUp(e *engine) (err error) {
 	syncer.OnEventType(event.StateMember, b.HandleStateMemberEvent)
 
 	err = client.Sync()
-
-	// save reference
-	e.bots[b.ID] = client
 
 	return
 }

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -15,6 +15,16 @@ type Bot struct {
 	Active      bool   `db:"active"`
 }
 
+func getActiveBots(dbs db.Session) (bots []Bot, err error) {
+	res := dbs.Collection("bots").Find(db.Cond{"active": 1})
+	err = res.All(&bots)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
 func getBot(dbs db.Session, identifier string) (b Bot, err error) {
 	res := dbs.Collection("bots").Find(db.Cond{"identifier": identifier})
 	err = res.One(&b)

--- a/engine/bots_test.go
+++ b/engine/bots_test.go
@@ -1,0 +1,61 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetActiveBots(t *testing.T) {
+	dbs, dbs2 := setUp()
+	defer tearDown(dbs, dbs2)
+
+	expected := []Bot{
+		{
+			ID:          2,
+			Name:        "AFK Bot",
+			Identifier:  "bot_afk",
+			Description: "Used to post AFK messages for team members",
+			Username:    "bot_afk",
+			Password:    "bot_afk",
+			CreatedBy:   "ashfame",
+			Active:      true,
+		},
+	}
+
+	got, _ := getActiveBots(dbs)
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("incorrect bot data")
+	}
+
+	_, err := getActiveBots(dbs2)
+	if err == nil {
+		t.Error("empty database didn't return error")
+	}
+}
+
+func TestGetBot(t *testing.T) {
+	dbs, dbs2 := setUp()
+	defer tearDown(dbs, dbs2)
+
+	tables := []struct {
+		identifier string
+		botID      uint64
+	}{
+		{
+			identifier: "bot_afk",
+			botID:      2,
+		},
+		{
+			identifier: "bot_none",
+			botID:      0, // nil value basically, database row doesn't exist
+		},
+	}
+
+	for _, table := range tables {
+		got, _ := getBot(dbs, table.identifier)
+		t.Log(got)
+		if table.botID != got.ID {
+			t.Errorf("didn't get what was expected. identifier: %s got: %d expected: %d", table.identifier, got.ID, table.botID)
+		}
+	}
+}

--- a/engine/bots_test.go
+++ b/engine/bots_test.go
@@ -59,3 +59,67 @@ func TestGetBot(t *testing.T) {
 		}
 	}
 }
+
+func TestBotIsHydrated(t *testing.T) {
+	b := &Bot{}
+	if b.IsHydrated() != false {
+		t.Error("empty bot instance should not be hydrated")
+	}
+
+	b.hydrated = true
+	if b.IsHydrated() != true {
+		t.Error("bot instance should be hydrated")
+	}
+
+}
+
+func TestBotHydration(t *testing.T) {
+	b := &Bot{}
+	b.Hydrate(NewMockEngine())
+
+	if b.IsHydrated() != true {
+		t.Error("bot instance should have been hydrated")
+	}
+
+	if b.e == nil {
+		t.Error("bot instance should have reference to engine it was hydrated with")
+	}
+}
+
+func TestBotGetMCInstance(t *testing.T) {
+	b := &Bot{}
+	if b.getMCInstance() != nil {
+		t.Error("bot matrix instance should have been nil as its not hydrated")
+	}
+
+	e := NewMockEngine()
+	e.bots = make(map[uint64]MatrixClient)
+	e.bots[0] = NewMockMatrixClient("bot")
+	b.Hydrate(e)
+
+	if b.getMCInstance() == nil {
+		t.Error("bot matrix instance should not have been nil as its now hydrated")
+	}
+}
+
+func TestBotJoinRoom(t *testing.T) {
+	b := &Bot{}
+	_, err := b.JoinRoom("whatever")
+	if err == nil {
+		t.Error("bot shouldn't have been able to join room without hydration")
+	}
+
+	e := NewMockEngine()
+	e.bots = make(map[uint64]MatrixClient)
+	e.bots[0] = NewMockMatrixClient("bot")
+	b.Hydrate(e)
+
+	_, err = b.JoinRoom("room1")
+	if err != nil {
+		t.Error("error thrown while joining a room")
+	}
+
+	if !b.getMCInstance().(*mockMatrixClient).WasRoomJoined("room1") {
+		t.Error("room wasn't joined when it should have")
+	}
+}

--- a/engine/db_test.go
+++ b/engine/db_test.go
@@ -435,6 +435,7 @@ func getDataInsertsSQL() *[]string {
 		`INSERT INTO "workflow_step_meta" ("id","step_id","key","value") VALUES (16,14,'messagePrefix','[Announcement]');`,
 
 		// Bots
+		`INSERT INTO "bots" ("id", "identifier", "name", "description", "username", "password", "created_by", "active") VALUES ('1', 'bot_something', '', '', '', '', 'ashfame', '0');`,
 		`INSERT INTO "bots" ("id", "identifier", "name", "description", "username", "password", "created_by", "active") VALUES ('2', 'bot_afk', 'AFK Bot', 'Used to post AFK messages for team members', 'bot_afk', 'bot_afk', 'ashfame', '1');`,
 	}
 }

--- a/engine/db_test.go
+++ b/engine/db_test.go
@@ -433,5 +433,8 @@ func getDataInsertsSQL() *[]string {
 		`INSERT INTO "workflow_step_meta" ("id","step_id","key","value") VALUES (14,13,'messagePrefix','[Alert]');`,
 		`INSERT INTO "workflow_step_meta" ("id","step_id","key","value") VALUES (15,14,'matrixRoom','');`,
 		`INSERT INTO "workflow_step_meta" ("id","step_id","key","value") VALUES (16,14,'messagePrefix','[Announcement]');`,
+
+		// Bots
+		`INSERT INTO "bots" ("id", "identifier", "name", "description", "username", "password", "created_by", "active") VALUES ('2', 'bot_afk', 'AFK Bot', 'Used to post AFK messages for team members', 'bot_afk', 'bot_afk', 'ashfame', '1');`,
 	}
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -114,6 +114,14 @@ func (e *engine) StartUp(mc MatrixClient, s mautrix.Syncer) {
 			e.log("Finished loading Matrix client.")
 		}()
 
+		go func() {
+			err := e.wakeUpMatrixBots()
+			if err != nil {
+				log.Fatal(err)
+			}
+			e.log("Finished waking up all Matrix bots.")
+		}()
+
 		// allow the matrix client to sync and be ready,
 		<-matrixInitDone
 	}
@@ -367,6 +375,24 @@ func (e *engine) initMatrixClient(c MatrixClient, s mautrix.Syncer, matrixInitDo
 	err = e.client.Sync()
 	if err != nil {
 		return
+	}
+
+	return
+}
+
+func (e *engine) wakeUpMatrixBots() (err error) {
+	// load all bots one by one and accept any invitations within our own homeserver
+
+	bots, err := getActiveBots(e.db)
+	if err != nil {
+		return
+	}
+
+	for _, b := range bots {
+		e.log(fmt.Sprintf("Matrix: Activating Bot: %s [%s]", b.Name, b.Identifier))
+
+		// @TODO handle login and sync
+
 	}
 
 	return

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -78,6 +78,7 @@ func (e *engine) StartUpLite() {
 	e.log("Starting up engine..")
 
 	// Initialize maps
+	e.bots = make(map[uint64]MatrixClient)
 	e.workflows = make(map[uint64]*workflow)
 	e.triggers = make(map[string]map[string]Trigger)
 	e.triggers["webhook"] = make(map[string]Trigger)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -412,12 +412,9 @@ func (e *engine) wakeUpMatrixBots() (err error) {
 		go func(b Bot) {
 			defer wg.Done()
 
-			c, err := b.WakeUp(e)
-			if err != nil {
+			if err := b.WakeUp(e); err != nil {
 				failedWakeUps = append(failedWakeUps, b.ID)
 			}
-
-			e.bots[b.ID] = c
 		}(b)
 
 	}

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -81,6 +81,14 @@ func (m *mockMatrixClient) Sync() error {
 	return nil
 }
 
+func (m *mockMatrixClient) JoinRoomByID(roomID id.RoomID) (resp *mautrix.RespJoinRoom, err error) {
+	if roomID == "" {
+		return nil, errors.New("")
+	}
+
+	return
+}
+
 func NewMockMatrixClient(creator string) MatrixClient {
 	return &mockMatrixClient{
 		instantiatedBy: creator,

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -36,6 +36,7 @@ func NewMockWorkflowStep(impact string) *mockWorkflowStep {
 type mockMatrixClient struct {
 	instantiatedBy string
 	msgs           []string
+	roomsJoined    []id.RoomID
 }
 
 func (m *mockMatrixClient) Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error) {
@@ -86,7 +87,19 @@ func (m *mockMatrixClient) JoinRoomByID(roomID id.RoomID) (resp *mautrix.RespJoi
 		return nil, errors.New("")
 	}
 
+	m.roomsJoined = append(m.roomsJoined, roomID)
+
 	return
+}
+
+func (m *mockMatrixClient) WasRoomJoined(room id.RoomID) bool {
+	for _, v := range m.roomsJoined {
+		if v == room {
+			return true
+		}
+	}
+
+	return false
 }
 
 func NewMockMatrixClient(creator string) MatrixClient {

--- a/engine/workflow_step_matrix_post_message.go
+++ b/engine/workflow_step_matrix_post_message.go
@@ -36,6 +36,10 @@ func (s postMessageMatrixWorkflowStep) getMatrixClient(e *engine) (mc MatrixClie
 			return nil, err
 		}
 
+		if !b.IsHydrated() {
+			b.Hydrate(e)
+		}
+
 		return b.getInstance(), nil
 	}
 

--- a/engine/workflow_step_matrix_post_message.go
+++ b/engine/workflow_step_matrix_post_message.go
@@ -40,7 +40,7 @@ func (s postMessageMatrixWorkflowStep) getMatrixClient(e *engine) (mc MatrixClie
 			b.Hydrate(e)
 		}
 
-		return b.getInstance(), nil
+		return b.getMCInstance(), nil
 	}
 
 	return e.client, nil

--- a/engine/workflow_step_matrix_post_message.go
+++ b/engine/workflow_step_matrix_post_message.go
@@ -36,22 +36,7 @@ func (s postMessageMatrixWorkflowStep) getMatrixClient(e *engine) (mc MatrixClie
 			return nil, err
 		}
 
-		mc, err := getMatrixClient(e.matrixhomeserver)
-		if err != nil {
-			return nil, err
-		}
-
-		_, err = mc.Login(&mautrix.ReqLogin{
-			Type:             "m.login.password",
-			Identifier:       mautrix.UserIdentifier{Type: mautrix.IdentifierTypeUser, User: b.Username},
-			Password:         b.Password,
-			StoreCredentials: true,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		return mc, nil
+		return b.getInstance(), nil
 	}
 
 	return e.client, nil

--- a/engine/workflow_step_matrix_post_message_test.go
+++ b/engine/workflow_step_matrix_post_message_test.go
@@ -67,7 +67,12 @@ func TestGetMatrixClient(t *testing.T) {
 		// When bot identifier is specified, use the matrix client instatiated by the particular bot credentials
 		{
 			asBot:        "bot_something",
-			clientOrigin: "bot",
+			clientOrigin: "bot1",
+		},
+		// When bot identifier is specified, use the matrix client instatiated by the particular bot credentials
+		{
+			asBot:        "bot_afk",
+			clientOrigin: "bot2",
 		},
 	}
 
@@ -80,6 +85,9 @@ func TestGetMatrixClient(t *testing.T) {
 		// setup mock engine
 		e := NewMockEngine()
 		e.db = dbs
+		e.bots = make(map[uint64]MatrixClient)
+		e.bots[1] = NewMockMatrixClient("bot1")
+		e.bots[2] = NewMockMatrixClient("bot2")
 
 		// get step instance
 		s := &postMessageMatrixWorkflowStep{

--- a/engine/workflow_step_matrix_post_message_test.go
+++ b/engine/workflow_step_matrix_post_message_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"testing"
 
-	"github.com/upper/db/v4"
 	"maunium.net/go/mautrix"
 )
 
@@ -80,7 +79,6 @@ func TestGetMatrixClient(t *testing.T) {
 		// setup db row in bots table
 		dbs, dbs2 := setUp()
 		defer tearDown(dbs, dbs2)
-		insertDummyBotForTesting(dbs)
 
 		// setup mock engine
 		e := NewMockEngine()
@@ -238,7 +236,6 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 	for _, table := range tables {
 		// setup db row in bots table
 		dbs, dbs2 := setUp()
-		insertDummyBotForTesting(dbs)
 
 		e := NewMockEngine()
 		e.db = dbs
@@ -281,11 +278,4 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 		tearDown(dbs, dbs2)
 	}
 
-}
-
-func insertDummyBotForTesting(db db.Session) {
-	db.Collection("bots").Insert(Bot{
-		ID:         1,
-		Identifier: "bot_something",
-	})
 }

--- a/engine/workflow_step_matrix_post_message_test.go
+++ b/engine/workflow_step_matrix_post_message_test.go
@@ -243,6 +243,8 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 		e := NewMockEngine()
 		e.db = dbs
 		e.matrixhomeserver = table.homeserver
+		e.bots = make(map[uint64]MatrixClient)
+		e.bots[1] = botMatrixClient
 
 		s := &postMessageMatrixWorkflowStep{
 			workflowStep: workflowStep{


### PR DESCRIPTION
This PR brings change to engine's architecture where all matrix client instances of all bots are now kept inside of engine. This way, all bots login into their own accounts at start of the program instead of just logging in when they need to post a message. This helps them stay in sync with all events that are happening in rooms they are part of, as they happen. Eg: Bots can immediately respond to invitations and join rooms. 

PostMessageMatrix workflow step is accordingly adapted to utilise the matrix instance of bot that it needs to use, as well.